### PR TITLE
Small Flux Optimization

### DIFF
--- a/docs/flux_queries/daily-totals.flux
+++ b/docs/flux_queries/daily-totals.flux
@@ -1,12 +1,12 @@
 // Daily totals of production and consumption
 from(bucket: "low_rate")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  // Shift back by 12 hours so that the bar chart shows up mid-day instead of at midnight
-  |> timeShift(duration: -12h)
   |> filter(fn: (r) => r["source"] == "power-meter")
   |> filter(fn: (r) => r["measurement-type"] == "consumption")
   |> filter(fn: (r) => r["interval"] == "24h")
   |> filter(fn: (r) => r["_field"] == "Wh")
+  // Shift back by 12 hours so that the bar chart shows up mid-day instead of at midnight
+  |> timeShift(duration: -12h)
   |> group(columns: ["_time"], mode:"by")
   |> sum(column: "_value")
   |> group()
@@ -14,11 +14,12 @@ from(bucket: "low_rate")
 
 from(bucket: "low_rate")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-  |> timeShift(duration: -12h)
   |> filter(fn: (r) => r["source"] == "power-meter")
   |> filter(fn: (r) => r["measurement-type"] == "production")
   |> filter(fn: (r) => r["interval"] == "24h")
   |> filter(fn: (r) => r["_field"] == "Wh")
+  // Shift back by 12 hours so that the bar chart shows up mid-day instead of at midnight
+  |> timeShift(duration: -12h)
   |> group(columns: ["_time"], mode:"by")
   |> sum(column: "_value")
   |> group()


### PR DESCRIPTION
https://docs.influxdata.com/influxdb/v2.7/query-data/optimize-queries/

Move `timeShift()` to after `filter()`.  In my setup, this reduces the query time from 15+ seconds (each) to hundredths of a second.
