### PR TITLE
Fix an issue with sleep where it throws KeyboardInterrupt on Ctrl-C

### DIFF
--- a/envoy_logger/sampling_loop.py
+++ b/envoy_logger/sampling_loop.py
@@ -2,6 +2,7 @@ from datetime import datetime, date
 import time
 from typing import List, Dict
 import logging
+import sys
 from requests.exceptions import ReadTimeout, ConnectTimeout
 
 from influxdb_client import WritePrecision, InfluxDBClient, Point
@@ -57,8 +58,11 @@ class SamplingLoop:
         now = datetime.now()
         time_to_next = self.interval - (now.timestamp() % self.interval)
 
-        # wait!
-        time.sleep(time_to_next)
+        try:
+            time.sleep(time_to_next)
+        except KeyboardInterrupt:
+            print('Exiting with Ctrl-C')
+            sys.exit(0)
 
         data = envoy.get_power_data(self.cfg.envoy_url, self.session_id)
 


### PR DESCRIPTION
This fixes an issue where if you Ctrl-C out of the program it logs an annoying KeyboardInterrupt exception. This captures the interrupt, logs the exit, and exits cleanly.